### PR TITLE
Modernize pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </distributionManagement>
 
   <build>
-    <sourceDirectory>${basedir}/src/main/java/</sourceDirectory>
+    <sourceDirectory>${project.basedir}/src/main/java/</sourceDirectory>
 
     <!-- Plugins -->
     <plugins>


### PR DESCRIPTION
{basedir} is now deprecated in the newer versions of Maven, the modern version is {project.basedir}
