### PR TITLE
Improve instantiation and error handling during command registration

### DIFF
--- a/core/src/main/java/com/sk89q/minecraft/util/commands/CommandRegistrationException.java
+++ b/core/src/main/java/com/sk89q/minecraft/util/commands/CommandRegistrationException.java
@@ -1,0 +1,22 @@
+package com.sk89q.minecraft.util.commands;
+
+/**
+ * A problem registering commands
+ */
+public class CommandRegistrationException extends RuntimeException {
+
+    public CommandRegistrationException() {
+    }
+
+    public CommandRegistrationException(String message) {
+        super(message);
+    }
+
+    public CommandRegistrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CommandRegistrationException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
* Don't try to instantiate classes until an instance method is encountered
* Throw an exception if instantiation fails (instead of silently ignoring the method)