### PR TITLE
Expand completion support

### DIFF
--- a/core/src/main/java/com/sk89q/minecraft/util/commands/CommandUsageException.java
+++ b/core/src/main/java/com/sk89q/minecraft/util/commands/CommandUsageException.java
@@ -19,16 +19,28 @@
 
 package com.sk89q.minecraft.util.commands;
 
+import javax.annotation.Nullable;
+
 public class CommandUsageException extends CommandException {
 
-    protected String usage;
+    protected @Nullable String usage;
 
-    public CommandUsageException(String message, String usage) {
+    public CommandUsageException(String message) {
+        this(message, null);
+    }
+
+    public CommandUsageException(String message, @Nullable String usage) {
         super(message);
         this.usage = usage;
     }
 
     public String getUsage() {
-        return usage;
+        return usage != null ? usage : "";
+    }
+
+    public void offerUsage(String usage) {
+        if(this.usage == null) {
+            this.usage = usage;
+        }
     }
 }

--- a/core/src/main/java/com/sk89q/minecraft/util/commands/SuggestException.java
+++ b/core/src/main/java/com/sk89q/minecraft/util/commands/SuggestException.java
@@ -1,0 +1,24 @@
+package com.sk89q.minecraft.util.commands;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Throw this exception out of a command method to suggest completions for the command.
+ *
+ * This is only allowed when {@link CommandContext#isSuggesting()} is true. If it isn't,
+ * then the exception is handled like any other uncaught exception.
+ */
+public class SuggestException extends Exception {
+
+    private final ImmutableList<String> suggestions;
+
+    public SuggestException(Iterable<String> suggestions) {
+        this.suggestions = ImmutableList.copyOf(suggestions);
+    }
+
+    public List<String> suggestions() {
+        return suggestions;
+    }
+}

--- a/core/src/main/java/com/sk89q/minecraft/util/commands/SuggestionContext.java
+++ b/core/src/main/java/com/sk89q/minecraft/util/commands/SuggestionContext.java
@@ -19,7 +19,10 @@
 
 package com.sk89q.minecraft.util.commands;
 
+import java.util.List;
 import javax.annotation.Nullable;
+
+import com.sk89q.util.StringUtil;
 
 /**
  * Extra information about the context in which tab-completion is happening
@@ -90,7 +93,58 @@ public class SuggestionContext {
     public @Nullable Character getFlag() {
         return flag;
     }
-    
+
+    /**
+     * Is the given argument being completed?
+     */
+    public boolean isArgument(int index) {
+        return isArgument() && getIndex() == index;
+    }
+
+    /**
+     * Is the given flag being completed?
+     */
+    public boolean isFlag(char flag) {
+        return isFlag() && getFlag() == flag;
+    }
+
+    /**
+     * Return the sorted subset of the given choices that are valid completions,
+     * i.e. that start with {@link #getPrefix()}.
+     */
+    public List<String> complete(Iterable<String> choices) {
+        return StringUtil.complete(getPrefix(), choices);
+    }
+
+    /**
+     * Suggest completions based on the given choices, by throwing a {@link SuggestException}.
+     *
+     * Only valid choices are used, and they are sorted alphabetically.
+     */
+    public void suggest(Iterable<String> choices) throws SuggestException {
+        throw new SuggestException(complete(choices));
+    }
+
+    /**
+     * If the given argument is being completed, generate suggestions from the given choices,
+     * by throwing a {@link SuggestException}.
+     */
+    public void suggestArgument(int index, Iterable<String> choices) throws SuggestException {
+        if(isArgument(index)) {
+            suggest(choices);
+        }
+    }
+
+    /**
+     * If the given flag is being completed, generate suggestions from the given choices,
+     * by throwing a {@link SuggestException}.
+     */
+    public void suggestFlag(char flag, Iterable<String> choices) throws SuggestException {
+        if(isFlag(flag)) {
+            suggest(choices);
+        }
+    }
+
     @Override
     public String toString() {
         return isArgument() ? "argument " + getIndex()

--- a/core/src/main/java/com/sk89q/util/StringUtil.java
+++ b/core/src/main/java/com/sk89q/util/StringUtil.java
@@ -19,7 +19,10 @@
 
 package com.sk89q.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -306,6 +309,19 @@ public final class StringUtil {
         }
 
         return type;
+    }
+
+    public static List<String> complete(String prefix, Iterable<String> options) {
+        final String prefixLower = prefix.toLowerCase();
+        final int pos = prefixLower.lastIndexOf(' ');
+        final List<String> matches = new ArrayList<>();
+        options.forEach(option -> {
+            if(option.toLowerCase().startsWith(prefixLower)) {
+                matches.add(pos == -1 ? option : option.substring(pos + 1));
+            }
+        });
+        Collections.sort(matches);
+        return matches;
     }
 }
 


### PR DESCRIPTION
* Command methods can throw a `SuggestException` to provide completions, instead of returning a `List<String>`.
* `CommandContext` has methods to simultaneously get an argument and provide completions for it, depending on what is happening. This allows completion to be implemented in a very convenient way:
```
String value = context.getString(0, choices);
```
If argument 0 is being completed, this throws a `SuggestException` with completions generated from `choices`. In other cases, it is equivalent to `getString(0)`. Similar methods are available for flags and joined strings.